### PR TITLE
CI: lint + build on PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #4.

Adds a dedicated CI workflow (separate from Pages deploy) that runs `pnpm run lint` and `pnpm run build` on pull requests and pushes.
