### PR TITLE
Add focus mode (N-hop neighborhood)

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -382,12 +382,15 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                   <ContextMenuItem
                     icon={Target}
                     onClick={() => {
+                      // If focus mode is already active, keep the current hop count when switching nodes.
                       setFocusNodeId(contextNode)
-                      setFocusDepth(1)
+                      if (!focusNodeId) {
+                        setFocusDepth(1)
+                      }
                       setContextMenuPos(null)
                     }}
                   >
-                    Focus (1 hop)
+                    Focus ({focusNodeId ? focusDepth : 1} hop{(focusNodeId ? focusDepth : 1) === 1 ? '' : 's'})
                   </ContextMenuItem>
                   {focusNodeId && (
                     <ContextMenuItem


### PR DESCRIPTION
Closes #1\n\n- Add focus mode from node context menu\n- Focus hides non-neighborhood nodes/edges; overlay allows adjusting hop count and clearing focus