### PR TITLE
Feedback link + issue templates; node edit dialog; edge label toggle

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Report something that isn't working
+title: 'bug: '
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: What did you expect to happen?
+      placeholder: Describe the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide steps so we can reproduce.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Share link (optional)
+      description: If you can, paste a share link that reproduces the problem.
+      placeholder: https://...
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser / OS / version, etc.
+      placeholder: |
+        - Browser:
+        - OS:
+        - Version:
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Anything else we should know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feedback / questions
+    url: https://github.com/Corvimia/polycule-graph/issues/new/choose
+    about: File an issue using a template

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: 'feat: '
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an improvement.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: I find it hard to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: It would be great if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Other ways to solve this could be...
+
+  - type: input
+    id: url
+    attributes:
+      label: Share link (optional)
+      description: If relevant, include a share link demonstrating the current behavior.
+      placeholder: https://...

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -186,7 +186,17 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, isMobile }: SidebarProps)
                   : 'py-3 text-center text-xs text-indigo-400 font-medium'
               }
             >
-              made with love by{' '}
+              <a
+                href="https://github.com/Corvimia/polycule-graph/issues/new/choose"
+                target="_blank"
+                rel="noreferrer"
+                className={
+                  dark ? 'text-white underline font-bold' : 'text-indigo-600 underline font-bold'
+                }
+              >
+                feedback
+              </a>{' '}
+              • made with love by{' '}
               <a
                 href="https://github.com/Corvimia"
                 target="_blank"
@@ -323,7 +333,17 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, isMobile }: SidebarProps)
             : 'py-3 text-center text-xs text-indigo-400 font-medium'
         }
       >
-        made with love by{' '}
+        <a
+          href="https://github.com/Corvimia/polycule-graph/issues/new/choose"
+          target="_blank"
+          rel="noreferrer"
+          className={
+            dark ? 'text-white underline font-bold' : 'text-indigo-600 underline font-bold'
+          }
+        >
+          feedback
+        </a>{' '}
+        • made with love by{' '}
         <a
           href="https://github.com/Corvimia"
           target="_blank"

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,16 @@ export interface GraphNode {
 
 export type EdgePattern = 'solid' | 'dashed' | 'dotted'
 
+export type EdgeLabelMode = 'always' | 'hover'
+
 export interface GraphEdgeData {
   label?: string
+  /**
+   * How edge labels are shown in the UI.
+   * - always: label is always visible
+   * - hover: label is only visible when hovering the edge
+   */
+  labelMode?: EdgeLabelMode
   color?: string
   width?: number
   pattern?: EdgePattern

--- a/src/utils/graphDot.ts
+++ b/src/utils/graphDot.ts
@@ -18,11 +18,15 @@ export function toDot(nodes: GraphNode[], edges: GraphEdge[]): string {
   }
   for (const edge of edges) {
     const label = edge.data?.label ? `label="${edge.data.label}"` : ''
+    const labelMode =
+      edge.data?.labelMode && edge.data.labelMode !== 'always'
+        ? `labelmode="${edge.data.labelMode}"`
+        : ''
     const color = edge.data?.color ? `color="${edge.data.color}"` : ''
     const width = edge.data?.width ? `penwidth=${edge.data.width}` : ''
     const pattern =
       edge.data?.pattern && edge.data.pattern !== 'solid' ? `style="${edge.data.pattern}"` : ''
-    const attrs = [label, color, width, pattern].filter(Boolean).join(', ')
+    const attrs = [label, labelMode, color, width, pattern].filter(Boolean).join(', ')
     dot += `  "${edge.source}" -- "${edge.target}"${attrs ? ` [${attrs}]` : ''};\n`
   }
   dot += '}'
@@ -115,6 +119,7 @@ export function dotAstToCytoscape(ast: DotAst): { nodes: GraphNode[]; edges: Gra
             type: 'smoothstep',
             data: {
               ...(attrs.label ? { label: attrs.label } : {}),
+              ...(attrs.labelmode ? { labelMode: attrs.labelmode as 'always' | 'hover' } : {}),
               ...(attrs.color ? { color: attrs.color } : {}),
               ...(attrs.penwidth ? { width: Number(attrs.penwidth) } : {}),
               ...(attrs.style ? { pattern: attrs.style as 'solid' | 'dashed' | 'dotted' } : {}),


### PR DESCRIPTION
Implements requested changes from issues #25, #26, #27:

- Adds a footer link named **feedback** pointing to the issue template chooser.
- Adds GitHub issue templates (bug report + feature request) and disables blank issues.
- Replaces the node context menu "Rename" with an **Edit Node** dialog (name + colour).
- Adds edge naming in the **Edit Edge** dialog (label + always/hover toggle), persisted to DOT via the `label` and `labelmode` attributes.

Notes:
- I interpreted "name" as the node label (not the node id).
- For hover labels, labels are hidden unless the edge is hovered.
