### PR TITLE
ci: ccc-track label + OpenClaw wake via mapped hook

### DIFF
--- a/.github/workflows/ccc-track.yml
+++ b/.github/workflows/ccc-track.yml
@@ -175,13 +175,12 @@ jobs:
             core.setOutput('should_wake', shouldWake ? 'true' : 'false');
             core.setOutput('json_b64', jsonB64);
 
-      - name: Connect to Tailscale (ephemeral)
+      - name: Connect to Tailscale
         if: ${{ steps.build.outputs.should_wake == 'true' }}
         uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          ephemeral: true
           # If your tailnet requires tags for CI nodes, uncomment and ensure ACLs allow it:
           # tags: tag:github-actions
 

--- a/.github/workflows/ccc-track.yml
+++ b/.github/workflows/ccc-track.yml
@@ -1,0 +1,207 @@
+name: ccc-track (label + wake OpenClaw)
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created, edited]
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ccc-track-${{ github.repository }}-${{ github.event_name }}-${{ github.event.action }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  track-and-wake:
+    # extra safety: never run outside Corvimia/*
+    if: ${{ github.repository_owner == 'Corvimia' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build payload, apply ccc-track label, and decide whether to wake
+        id: build
+        uses: actions/github-script@v7
+        env:
+          TRACK_LABEL: ccc-track
+          MENTION_USER: CoralCorvusCortex
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const trackLabel = process.env.TRACK_LABEL;
+            const mentionUser = process.env.MENTION_USER;
+
+            const mentionRe = new RegExp(`@${mentionUser}\\b`, 'i');
+
+            function trunc(s, max) {
+              if (!s) return '';
+              if (s.length <= max) return s;
+              return s.slice(0, max) + `\n…(truncated ${s.length - max} chars)`;
+            }
+
+            // Determine the thread (issue/pr) and the content object for this event
+            const p = context.payload;
+
+            // Thread
+            const issueLike = p.issue;
+            const prLike = p.pull_request;
+
+            let threadType = null;
+            let number = null;
+            let title = null;
+            let htmlUrl = null;
+
+            if (issueLike) {
+              threadType = issueLike.pull_request ? 'pr' : 'issue';
+              number = issueLike.number;
+              title = issueLike.title;
+              htmlUrl = issueLike.html_url;
+            } else if (prLike) {
+              threadType = 'pr';
+              number = prLike.number;
+              title = prLike.title;
+              htmlUrl = prLike.html_url;
+            } else {
+              core.setFailed('Unsupported payload: expected issue or pull_request');
+              return;
+            }
+
+            // Content
+            let contentKind = null;
+            let contentUrl = null;
+            let contentBody = '';
+
+            if (p.comment) {
+              // issue_comment or pull_request_review_comment
+              contentKind = (context.eventName === 'pull_request_review_comment') ? 'pr_review_comment' : 'issue_comment';
+              contentUrl = p.comment.html_url;
+              contentBody = p.comment.body || '';
+            } else if (p.review) {
+              // pull_request_review
+              contentKind = 'pr_review';
+              contentUrl = (p.review.html_url || (prLike ? `${prLike.html_url}#pullrequestreview-${p.review.id}` : null));
+              contentBody = p.review.body || '';
+            } else if (issueLike) {
+              // issues opened/edited
+              contentKind = 'issue_body';
+              contentUrl = issueLike.html_url;
+              contentBody = issueLike.body || '';
+            } else if (prLike) {
+              // pull_request opened/edited/synchronize
+              contentKind = 'pr_body';
+              contentUrl = prLike.html_url;
+              contentBody = prLike.body || '';
+            }
+
+            const mentionDetected = mentionRe.test(contentBody);
+
+            // Helper: fetch live labels from GitHub (don’t trust payload)
+            async function fetchLabels() {
+              const res = await github.rest.issues.get({ owner, repo, issue_number: number });
+              const labels = (res.data.labels || []).map(l => (typeof l === 'string' ? l : l.name)).filter(Boolean);
+              return labels;
+            }
+
+            // Apply label on mention (idempotent)
+            if (mentionDetected) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: number,
+                labels: [trackLabel],
+              });
+            }
+
+            const labels = await fetchLabels();
+            const tracked = labels.map(l => String(l).toLowerCase()).includes(trackLabel.toLowerCase());
+
+            // Wake on original mention OR on any activity for tracked threads
+            const shouldWake = mentionDetected || tracked;
+
+            const payload = {
+              source: 'github',
+              schema: 'ccc-track/v1',
+              idempotencyKey: `gh:${context.runId}:${context.runAttempt}`,
+              event: {
+                name: context.eventName,
+                action: p.action || null,
+                run: { id: context.runId, attempt: context.runAttempt },
+              },
+              repo: {
+                owner,
+                name: repo,
+                full_name: `${owner}/${repo}`,
+                html_url: `https://github.com/${owner}/${repo}`,
+              },
+              actor: {
+                login: context.actor,
+                html_url: `https://github.com/${context.actor}`,
+              },
+              thread: {
+                type: threadType,
+                number,
+                title,
+                html_url: htmlUrl,
+                labels,
+              },
+              content: {
+                kind: contentKind,
+                html_url: contentUrl,
+                body: trunc(contentBody, 12000),
+                body_truncated: (contentBody || '').length > 12000,
+              },
+              signals: {
+                mention_user: `@${mentionUser}`,
+                mention_detected: mentionDetected,
+                tracked,
+                should_wake: shouldWake,
+              },
+            };
+
+            const json = JSON.stringify(payload);
+            const jsonB64 = Buffer.from(json, 'utf8').toString('base64');
+
+            core.setOutput('should_wake', shouldWake ? 'true' : 'false');
+            core.setOutput('json_b64', jsonB64);
+
+      - name: POST to OpenClaw mapped hook (/hooks/github)
+        if: ${{ steps.build.outputs.should_wake == 'true' }}
+        env:
+          OPENCLAW_BASE_URL: ${{ secrets.OPENCLAW_BASE_URL }}
+          OPENCLAW_HOOK_TOKEN: ${{ secrets.OPENCLAW_HOOK_TOKEN }}
+          JSON_B64: ${{ steps.build.outputs.json_b64 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${OPENCLAW_BASE_URL:-}" ]]; then
+            echo "Missing secret: OPENCLAW_BASE_URL" >&2
+            exit 1
+          fi
+
+          if [[ -z "${OPENCLAW_HOOK_TOKEN:-}" ]]; then
+            echo "Missing secret: OPENCLAW_HOOK_TOKEN" >&2
+            exit 1
+          fi
+
+          tmpfile="$(mktemp)"
+          trap 'rm -f "$tmpfile"' EXIT
+
+          echo "$JSON_B64" | base64 -d > "$tmpfile"
+
+          # Avoid leaking payload/token into logs. Keep curl quiet unless failing.
+          curl --fail-with-body --silent --show-error \
+            -X POST "${OPENCLAW_BASE_URL%/}/hooks/github" \
+            -H "Authorization: Bearer ${OPENCLAW_HOOK_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data-binary "@$tmpfile"

--- a/.github/workflows/ccc-track.yml
+++ b/.github/workflows/ccc-track.yml
@@ -181,8 +181,7 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          # If your tailnet requires tags for CI nodes, uncomment and ensure ACLs allow it:
-          # tags: tag:github-actions
+          tags: tag:github-actions
 
       - name: POST to OpenClaw mapped hook (/hooks/github)
         if: ${{ steps.build.outputs.should_wake == 'true' }}

--- a/.github/workflows/ccc-track.yml
+++ b/.github/workflows/ccc-track.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: ccc-track-${{ github.repository }}-${{ github.event_name }}-${{ github.event.action }}-${{ github.run_id }}
@@ -174,20 +175,25 @@ jobs:
             core.setOutput('should_wake', shouldWake ? 'true' : 'false');
             core.setOutput('json_b64', jsonB64);
 
+      - name: Connect to Tailscale (ephemeral)
+        if: ${{ steps.build.outputs.should_wake == 'true' }}
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          ephemeral: true
+          # If your tailnet requires tags for CI nodes, uncomment and ensure ACLs allow it:
+          # tags: tag:github-actions
+
       - name: POST to OpenClaw mapped hook (/hooks/github)
         if: ${{ steps.build.outputs.should_wake == 'true' }}
         env:
-          OPENCLAW_BASE_URL: ${{ secrets.OPENCLAW_BASE_URL }}
+          OPENCLAW_BASE_URL: https://synthetic-cognition-lab.tiger-cardassian.ts.net/
           OPENCLAW_HOOK_TOKEN: ${{ secrets.OPENCLAW_HOOK_TOKEN }}
           JSON_B64: ${{ steps.build.outputs.json_b64 }}
         shell: bash
         run: |
           set -euo pipefail
-
-          if [[ -z "${OPENCLAW_BASE_URL:-}" ]]; then
-            echo "Missing secret: OPENCLAW_BASE_URL" >&2
-            exit 1
-          fi
 
           if [[ -z "${OPENCLAW_HOOK_TOKEN:-}" ]]; then
             echo "Missing secret: OPENCLAW_HOOK_TOKEN" >&2


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that:

- Applies the **ccc-track** label when **@CoralCorvusCortex** is mentioned (issues/PRs/bodies/comments/reviews).
- On any activity for a **ccc-track** issue/PR (including the original mention event), POSTs a compact JSON envelope to your OpenClaw server’s mapped hook: **POST /hooks/github** (auth via `Authorization: Bearer …`).

## Why

This replaces polling/cron-style discovery with GitHub-native event triggers, while keeping the OpenClaw ingress secure (header token) and minimizing the payload sent to OpenClaw.

## How it works (high level)

- Workflow triggers on: `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`.
- It detects `@CoralCorvusCortex` in the relevant text field for that event type.
- If mentioned, it applies `ccc-track` (idempotent) to the parent issue/PR.
- It fetches live labels and, if `mention_detected || tracked`, calls OpenClaw.
- The runner joins your Tailscale tailnet ephemerally (OIDC/OAuth) before POSTing to the hook (private-only).
- Payload is base64-encoded between steps to avoid multiline-output issues, then POSTed as JSON.

## Secure setup checklist (things to do outside this PR)

### GitHub (repo/org config)

- [x] Create the label **`ccc-track`** in the repo (or org default labels). *(GitHub API `addLabels` fails if the label doesn’t exist.)*
- [ ] Add repo/org secrets:
  - [ ] `OPENCLAW_HOOK_TOKEN` — the OpenClaw webhook token (dedicated secret; don’t reuse gateway auth)
  - [x] `TS_OAUTH_CLIENT_ID` — Tailscale OAuth client id (for ephemeral CI nodes)
  - [x] `TS_OAUTH_SECRET` — Tailscale OAuth client secret
- [ ] Confirm the workflow has permission to apply labels (it requests `issues: write`, `pull-requests: write`).

### OpenClaw (gateway config + network)

- [x] Ensure the OpenClaw Gateway is reachable **over Tailscale** from GitHub-hosted runners once they join the tailnet.
  - This workflow targets MagicDNS: `https://synthetic-cognition-lab.tiger-cardassian.ts.net/` (private-only).
- [x] Enable webhooks and require header auth (per docs):
  - [x] `hooks.enabled=true`
  - [x] `hooks.token=<OPENCLAW_HOOK_TOKEN>`
  - [x] Keep `hooks.path` as `/hooks` (or update the workflow URL accordingly)
- [ ] Configure a mapped hook for **`/hooks/github`** that runs an isolated agent turn:
  - [ ] `match.path: "github"`
  - [ ] `action: "agent"`
  - [ ] `wakeMode: "now"`
  - [ ] (Recommended) `sessionKey: "hook:github:{{repo.full_name}}#{{thread.number}}"` for per-thread continuity
  - [ ] Provide a `transform` module that validates the incoming JSON (`schema=ccc-track/v1`) and builds the agent prompt from the payload.
- [ ] Security hardening (recommended):
  - [x] Put `/hooks/*` behind TLS (HTTPS)
  - [x] Do **not** expose `?token=` auth externally; use `Authorization: Bearer …` only
  - [x] Keep the hook token dedicated + rotateable
  - [ ] Keep `allowUnsafeExternalContent` **unset/false** for this mapping (default safety wrapper stays on)

## Testing checklist

- [ ] Mention `@CoralCorvusCortex` in a test issue comment → verify `ccc-track` is applied.
- [ ] Add another comment on that issue → verify the workflow POSTs to `/hooks/github`.
- [ ] Verify OpenClaw creates/uses the expected isolated session key and posts a summary back to main.
