### PR TITLE
Add edge labels with hover toggle

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -254,20 +254,29 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                 },
               }
             }),
-            ...edges.map(e => ({
-              ...e,
-              data: {
-                id: e.id,
-                source: e.source,
-                target: e.target,
-                label: e.data.label ?? '',
-                labelMode: e.data.labelMode ?? 'always',
-                color: e.data.color ?? '#bdbdbd',
-                width: e.data.width ?? 3,
-                pattern: e.data.pattern ?? 'solid',
-                directed: e.directed !== false, // default to true if undefined
-              },
-            })),
+            ...edges.map(e => {
+              const labelMode = e.data.labelMode ?? 'always'
+              const modeClass = labelMode === 'hover' ? 'edge-label-hover' : 'edge-label-always'
+              const maybeWithClasses = e as unknown as { classes?: unknown }
+              const existingClasses = typeof maybeWithClasses.classes === 'string' ? maybeWithClasses.classes : ''
+              const classes = [existingClasses, modeClass].filter(Boolean).join(' ')
+
+              return {
+                ...e,
+                classes,
+                data: {
+                  id: e.id,
+                  source: e.source,
+                  target: e.target,
+                  label: e.data.label ?? '',
+                  labelMode,
+                  color: e.data.color ?? '#bdbdbd',
+                  width: e.data.width ?? 3,
+                  pattern: e.data.pattern ?? 'solid',
+                  directed: e.directed !== false, // default to true if undefined
+                },
+              }
+            }),
           ]}
           style={{
             width: '80vw',
@@ -354,23 +363,39 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                 'target-arrow-color': 'data(color)',
                 'line-style': 'data(pattern)',
                 'curve-style': 'bezier',
+
+                // Labels
                 label: 'data(label)',
-                'font-size': 16,
-                color: '#a5b4fc',
+                'font-size': 14,
+                color: '#e5e7eb',
+                'text-wrap': 'wrap',
+                'text-max-width': 160,
+                'text-background-color': '#000',
+                'text-background-opacity': 0.45,
+                'text-background-shape': 'roundrectangle',
+                'text-background-padding': 4,
+                'text-outline-color': '#000',
+                'text-outline-width': 2,
+                'text-outline-opacity': 0.35,
+
                 'target-arrow-shape': 'none',
                 opacity: 0.95,
               },
             },
             {
-              selector: 'edge[labelMode = "hover"]',
+              selector: 'edge.edge-label-hover',
               style: {
                 'text-opacity': 0,
+                'text-background-opacity': 0,
+                'text-outline-opacity': 0,
               },
             },
             {
-              selector: 'edge[labelMode = "hover"]:hover',
+              selector: 'edge.edge-label-hover:hover',
               style: {
                 'text-opacity': 1,
+                'text-background-opacity': 0.45,
+                'text-outline-opacity': 0.35,
               },
             },
             {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -36,6 +36,8 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
   const [renameValue, setRenameValue] = useState('')
 
   const [editingEdge, setEditingEdge] = useState<string | null>(null)
+  const [edgeLabel, setEdgeLabel] = useState('')
+  const [edgeLabelMode, setEdgeLabelMode] = useState<'always' | 'hover'>('always')
   const [edgePattern, setEdgePattern] = useState<'solid' | 'dashed' | 'dotted'>('solid')
   const [edgeColor, setEdgeColor] = useState<string>('#bdbdbd')
   const [edgeWidth, setEdgeWidth] = useState<number>(3)
@@ -157,6 +159,8 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
     const edge = edges.find(e => e.id === editingEdge)
     if (!edge) return
 
+    setEdgeLabel(edge.data.label ?? '')
+    setEdgeLabelMode(edge.data.labelMode ?? 'always')
     setEdgePattern(edge.data.pattern ?? 'solid')
     setEdgeColor(edge.data.color ?? '#bdbdbd')
     setEdgeWidth(edge.data.width ?? 3)
@@ -257,6 +261,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                 source: e.source,
                 target: e.target,
                 label: e.data.label ?? '',
+                labelMode: e.data.labelMode ?? 'always',
                 color: e.data.color ?? '#bdbdbd',
                 width: e.data.width ?? 3,
                 pattern: e.data.pattern ?? 'solid',
@@ -354,6 +359,18 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                 color: '#a5b4fc',
                 'target-arrow-shape': 'none',
                 opacity: 0.95,
+              },
+            },
+            {
+              selector: 'edge[labelMode = "hover"]',
+              style: {
+                'text-opacity': 0,
+              },
+            },
+            {
+              selector: 'edge[labelMode = "hover"]:hover',
+              style: {
+                'text-opacity': 1,
               },
             },
             {
@@ -675,6 +692,38 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
               <div className="space-y-4">
                 <div>
                   <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+                    Label
+                  </div>
+                  <input
+                    type="text"
+                    value={edgeLabel}
+                    onChange={e => setEdgeLabel(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    placeholder="(optional)"
+                  />
+
+                  <div className="mt-3 flex items-center gap-4">
+                    {(
+                      [
+                        { value: 'always', label: 'Always' },
+                        { value: 'hover', label: 'On hover' },
+                      ] as const
+                    ).map(opt => (
+                      <label key={opt.value} className="flex items-center gap-2 text-sm">
+                        <input
+                          type="radio"
+                          name="edge-label-mode"
+                          value={opt.value}
+                          checked={edgeLabelMode === opt.value}
+                          onChange={() => setEdgeLabelMode(opt.value)}
+                        />
+                        <span className="text-gray-800 dark:text-gray-100">{opt.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                     Pattern
                   </div>
                   <div className="space-y-2">
@@ -781,6 +830,8 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                   onClick={() => {
                     if (!editingEdge) return
                     updateEdge(editingEdge, {
+                      label: edgeLabel.trim(),
+                      labelMode: edgeLabelMode,
                       color: edgeColor,
                       width: edgeWidth,
                       pattern: edgePattern,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,16 @@ export interface GraphNode {
 
 export type EdgePattern = 'solid' | 'dashed' | 'dotted'
 
+export type EdgeLabelMode = 'always' | 'hover'
+
 export interface GraphEdgeData {
   label?: string
+  /**
+   * How edge labels are shown in the UI.
+   * - always: label is always visible
+   * - hover: label is only visible when hovering the edge
+   */
+  labelMode?: EdgeLabelMode
   color?: string
   width?: number
   pattern?: EdgePattern

--- a/src/utils/graphDot.ts
+++ b/src/utils/graphDot.ts
@@ -18,11 +18,15 @@ export function toDot(nodes: GraphNode[], edges: GraphEdge[]): string {
   }
   for (const edge of edges) {
     const label = edge.data?.label ? `label="${edge.data.label}"` : ''
+    const labelMode =
+      edge.data?.labelMode && edge.data.labelMode !== 'always'
+        ? `labelmode="${edge.data.labelMode}"`
+        : ''
     const color = edge.data?.color ? `color="${edge.data.color}"` : ''
     const width = edge.data?.width ? `penwidth=${edge.data.width}` : ''
     const pattern =
       edge.data?.pattern && edge.data.pattern !== 'solid' ? `style="${edge.data.pattern}"` : ''
-    const attrs = [label, color, width, pattern].filter(Boolean).join(', ')
+    const attrs = [label, labelMode, color, width, pattern].filter(Boolean).join(', ')
     dot += `  "${edge.source}" -- "${edge.target}"${attrs ? ` [${attrs}]` : ''};\n`
   }
   dot += '}'
@@ -115,6 +119,7 @@ export function dotAstToCytoscape(ast: DotAst): { nodes: GraphNode[]; edges: Gra
             type: 'smoothstep',
             data: {
               ...(attrs.label ? { label: attrs.label } : {}),
+              ...(attrs.labelmode ? { labelMode: attrs.labelmode as 'always' | 'hover' } : {}),
               ...(attrs.color ? { color: attrs.color } : {}),
               ...(attrs.penwidth ? { width: Number(attrs.penwidth) } : {}),
               ...(attrs.style ? { pattern: attrs.style as 'solid' | 'dashed' | 'dotted' } : {}),


### PR DESCRIPTION
Fixes #26.

- Adds an optional edge label field to the edge edit dialog.
- Adds a visibility toggle: **Always** vs **On hover**.
- Persists to DOT using `label` + `labelmode` attributes.