### PR TITLE
Add edit node dialog

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -3,7 +3,7 @@ import { Plus, Trash2, Edit3, RotateCcw, Target, X, Minus, Save } from 'lucide-r
 import { useGraphContext } from '../contexts/GraphContext/GraphContext'
 import { useTheme } from '../contexts/ThemeContext/ThemeContext'
 import type cytoscape from 'cytoscape'
-import { stringToColor } from '../utils/graphDot'
+import { normalizeColorToHex, stringToColor } from '../utils/graphDot'
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useCytoscapeInteractions } from '../hooks/useCytoscapeInteractions'
 import { ContextMenu, ContextMenuItem, ContextMenuRoot } from './ui/context-menu'
@@ -250,7 +250,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                 data: {
                   id: n.id,
                   label,
-                  color: n.data.color ?? stringToColor(label), // hash-based color
+                  color: normalizeColorToHex(n.data.color ?? stringToColor(label)), // hash-based color
                 },
               }
             }),
@@ -459,7 +459,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                     onClick={() => {
                       const node = nodes.find(n => n.id === contextNode)
                       const label = node?.data.label ?? contextNode
-                      const color = node?.data.color ?? stringToColor(label)
+                      const color = normalizeColorToHex(node?.data.color ?? stringToColor(label))
 
                       setNodeEditLabel(label)
                       setNodeEditColor(color)
@@ -646,7 +646,10 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                         if (!renamingNode || renameError) return
                         const nextLabel = nodeEditLabel.trim()
                         renameNode(renamingNode, sanitizedNextNodeId, nextLabel)
-                        updateNode(sanitizedNextNodeId, { label: nextLabel, color: nodeEditColor })
+                        updateNode(sanitizedNextNodeId, {
+                          label: nextLabel,
+                          color: normalizeColorToHex(nodeEditColor),
+                        })
                         setRenamingNode(null)
                       } else if (e.key === 'Escape') {
                         setRenamingNode(null)
@@ -669,14 +672,16 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                     <input
                       type="color"
                       value={nodeEditColor}
-                      onChange={e => setNodeEditColor(e.target.value)}
+                      onChange={e => setNodeEditColor(normalizeColorToHex(e.target.value, nodeEditColor))}
                       className="h-10 w-12 rounded border border-gray-300 dark:border-gray-600 bg-transparent"
                       aria-label="Node colour"
                     />
                     <input
                       type="text"
                       value={nodeEditColor}
-                      onChange={e => setNodeEditColor(e.target.value)}
+                      onChange={e =>
+                        setNodeEditColor(normalizeColorToHex(e.target.value, nodeEditColor))
+                      }
                       className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
                       placeholder="#bdbdbd"
                     />
@@ -695,7 +700,10 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                       if (!renamingNode || renameError) return
                       const nextLabel = nodeEditLabel.trim()
                       renameNode(renamingNode, sanitizedNextNodeId, nextLabel)
-                      updateNode(sanitizedNextNodeId, { label: nextLabel, color: nodeEditColor })
+                      updateNode(sanitizedNextNodeId, {
+                        label: nextLabel,
+                        color: normalizeColorToHex(nodeEditColor),
+                      })
                       setRenamingNode(null)
                     }}
                     disabled={!!renameError || !renamingNode}

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -22,6 +22,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
     deleteEdge,
     addNode,
     renameNode,
+    updateNode,
     updateEdge,
     setNodePosition,
   } = useGraphContext()
@@ -29,11 +30,13 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
   const hasAnyDotPositions = nodes.some(n => !!n.position)
   const [cy, setCy] = useState<cytoscape.Core | undefined>(undefined)
   const contextMenuRef = useRef<HTMLDivElement>(null)
-  const renameInputRef = useRef<HTMLInputElement>(null)
+  const editNameInputRef = useRef<HTMLInputElement>(null)
   const pendingNodePlacementsRef = useRef<Record<string, { x: number; y: number }>>({})
   const initialLayoutAttemptedRef = useRef(false)
   const [isLayoutRunning, setIsLayoutRunning] = useState(false)
-  const [renameValue, setRenameValue] = useState('')
+  const [nodeEditLabel, setNodeEditLabel] = useState('')
+  const [nodeEditId, setNodeEditId] = useState('')
+  const [nodeEditColor, setNodeEditColor] = useState<string>('#bdbdbd')
 
   const [editingEdge, setEditingEdge] = useState<string | null>(null)
   const [edgePattern, setEdgePattern] = useState<'solid' | 'dashed' | 'dotted'>('solid')
@@ -122,14 +125,15 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
     setEdgeSource,
     setRenamingNode,
   } = useCytoscapeInteractions(cy)
-  const sanitizedRenameId = sanitizeNodeId(renameValue)
+
+  const sanitizedNextNodeId = sanitizeNodeId(nodeEditId)
   const hasDuplicateId =
     !!renamingNode &&
-    sanitizedRenameId.length > 0 &&
-    sanitizedRenameId !== renamingNode &&
-    nodes.some(n => n.id === sanitizedRenameId)
+    sanitizedNextNodeId.length > 0 &&
+    sanitizedNextNodeId !== renamingNode &&
+    nodes.some(n => n.id === sanitizedNextNodeId)
   const renameError =
-    sanitizedRenameId.length === 0
+    sanitizedNextNodeId.length === 0
       ? 'ID must include at least one letter or number.'
       : hasDuplicateId
         ? 'ID already exists.'
@@ -144,10 +148,12 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
     }
   }, [contextMenuPos, setContextMenuPos])
 
-  // Reset rename value when dialog closes
+  // Reset edit values when dialog closes
   useEffect(() => {
     if (!renamingNode) {
-      setRenameValue('')
+      setNodeEditLabel('')
+      setNodeEditId('')
+      setNodeEditColor('#bdbdbd')
     }
   }, [renamingNode])
 
@@ -454,12 +460,20 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                     icon={Edit3}
                     onClick={() => {
                       const node = nodes.find(n => n.id === contextNode)
-                      setRenameValue(node?.data.label || contextNode)
+                      const label = node?.data.label ?? contextNode
+                      const color = node?.data.color ?? stringToColor(label)
+
+                      setNodeEditLabel(label)
+                      setNodeEditId(contextNode)
+                      setNodeEditColor(color)
                       setRenamingNode(contextNode)
                       setContextMenuPos(null)
+
+                      // Ensure the input focuses after open
+                      setTimeout(() => editNameInputRef.current?.focus(), 0)
                     }}
                   >
-                    Rename
+                    Edit node
                   </ContextMenuItem>
                   <ContextMenuItem
                     icon={Target}
@@ -610,55 +624,102 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
           )}
         </ContextMenuRoot>
 
-        {/* Rename Node Dialog */}
+        {/* Edit Node Dialog */}
         {renamingNode && (
           <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
             <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-xl max-w-sm w-full mx-4">
               <h3 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
-                Rename Node
+                Edit node
               </h3>
-              <input
-                ref={renameInputRef}
-                type="text"
-                value={renameValue}
-                onChange={e => setRenameValue(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                autoFocus
-                onKeyDown={e => {
-                  if (e.key === 'Enter') {
-                    if (!renamingNode || renameError) return
-                    const newLabel = (e.target as HTMLInputElement).value
-                    renameNode(renamingNode, sanitizedRenameId, newLabel)
-                    setRenamingNode(null)
-                  } else if (e.key === 'Escape') {
-                    setRenamingNode(null)
-                  }
-                }}
-              />
-              <div className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                ID: <span className="font-mono">{sanitizedRenameId || '—'}</span>
-              </div>
-              {renameError && (
-                <div className="mt-2 text-sm text-red-600 dark:text-red-400">{renameError}</div>
-              )}
-              <div className="flex gap-2 mt-4">
-                <button
-                  onClick={() => setRenamingNode(null)}
-                  className="flex-1 px-4 py-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={() => {
-                    if (!renamingNode || renameError) return
-                    renameNode(renamingNode, sanitizedRenameId, renameValue)
-                    setRenamingNode(null)
-                  }}
-                  disabled={!!renameError || !renamingNode}
-                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:bg-gray-400 disabled:text-gray-200 transition-colors"
-                >
-                  Rename
-                </button>
+
+              <div className="space-y-4">
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+                    Name
+                  </div>
+                  <input
+                    ref={editNameInputRef}
+                    type="text"
+                    value={nodeEditLabel}
+                    onChange={e => setNodeEditLabel(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    autoFocus
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        if (!renamingNode || renameError) return
+                        const nextLabel = nodeEditLabel.trim() || sanitizedNextNodeId
+                        renameNode(renamingNode, sanitizedNextNodeId, nextLabel)
+                        updateNode(sanitizedNextNodeId, { label: nextLabel, color: nodeEditColor })
+                        setRenamingNode(null)
+                      } else if (e.key === 'Escape') {
+                        setRenamingNode(null)
+                      }
+                    }}
+                  />
+                </div>
+
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+                    Node ID
+                  </div>
+                  <input
+                    type="text"
+                    value={nodeEditId}
+                    onChange={e => setNodeEditId(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+                    placeholder="alice"
+                  />
+                  <div className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                    Sanitized: <span className="font-mono">{sanitizedNextNodeId || '—'}</span>
+                  </div>
+                  {renameError && (
+                    <div className="mt-2 text-sm text-red-600 dark:text-red-400">{renameError}</div>
+                  )}
+                </div>
+
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+                    Colour
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="color"
+                      value={nodeEditColor}
+                      onChange={e => setNodeEditColor(e.target.value)}
+                      className="h-10 w-12 rounded border border-gray-300 dark:border-gray-600 bg-transparent"
+                      aria-label="Node colour"
+                    />
+                    <input
+                      type="text"
+                      value={nodeEditColor}
+                      onChange={e => setNodeEditColor(e.target.value)}
+                      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+                      placeholder="#bdbdbd"
+                    />
+                  </div>
+                </div>
+
+                <div className="flex gap-2 pt-2">
+                  <button
+                    onClick={() => setRenamingNode(null)}
+                    className="flex-1 px-4 py-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => {
+                      if (!renamingNode || renameError) return
+                      const nextLabel = nodeEditLabel.trim() || sanitizedNextNodeId
+                      renameNode(renamingNode, sanitizedNextNodeId, nextLabel)
+                      updateNode(sanitizedNextNodeId, { label: nextLabel, color: nodeEditColor })
+                      setRenamingNode(null)
+                    }}
+                    disabled={!!renameError || !renamingNode}
+                    className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:bg-gray-400 disabled:text-gray-200 transition-colors"
+                  >
+                    Save
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -35,7 +35,6 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
   const initialLayoutAttemptedRef = useRef(false)
   const [isLayoutRunning, setIsLayoutRunning] = useState(false)
   const [nodeEditLabel, setNodeEditLabel] = useState('')
-  const [nodeEditId, setNodeEditId] = useState('')
   const [nodeEditColor, setNodeEditColor] = useState<string>('#bdbdbd')
 
   const [editingEdge, setEditingEdge] = useState<string | null>(null)
@@ -126,7 +125,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
     setRenamingNode,
   } = useCytoscapeInteractions(cy)
 
-  const sanitizedNextNodeId = sanitizeNodeId(nodeEditId)
+  const sanitizedNextNodeId = sanitizeNodeId(nodeEditLabel.trim())
   const hasDuplicateId =
     !!renamingNode &&
     sanitizedNextNodeId.length > 0 &&
@@ -152,7 +151,6 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
   useEffect(() => {
     if (!renamingNode) {
       setNodeEditLabel('')
-      setNodeEditId('')
       setNodeEditColor('#bdbdbd')
     }
   }, [renamingNode])
@@ -464,7 +462,6 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                       const color = node?.data.color ?? stringToColor(label)
 
                       setNodeEditLabel(label)
-                      setNodeEditId(contextNode)
                       setNodeEditColor(color)
                       setRenamingNode(contextNode)
                       setContextMenuPos(null)
@@ -647,7 +644,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                     onKeyDown={e => {
                       if (e.key === 'Enter') {
                         if (!renamingNode || renameError) return
-                        const nextLabel = nodeEditLabel.trim() || sanitizedNextNodeId
+                        const nextLabel = nodeEditLabel.trim()
                         renameNode(renamingNode, sanitizedNextNodeId, nextLabel)
                         updateNode(sanitizedNextNodeId, { label: nextLabel, color: nodeEditColor })
                         setRenamingNode(null)
@@ -656,21 +653,8 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                       }
                     }}
                   />
-                </div>
-
-                <div>
-                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
-                    Node ID
-                  </div>
-                  <input
-                    type="text"
-                    value={nodeEditId}
-                    onChange={e => setNodeEditId(e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
-                    placeholder="alice"
-                  />
                   <div className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                    Sanitized: <span className="font-mono">{sanitizedNextNodeId || '—'}</span>
+                    Node ID: <span className="font-mono">{sanitizedNextNodeId || '—'}</span>
                   </div>
                   {renameError && (
                     <div className="mt-2 text-sm text-red-600 dark:text-red-400">{renameError}</div>
@@ -709,7 +693,7 @@ export function GraphView({ sidebarOpen, isMobile }: GraphViewProps) {
                   <button
                     onClick={() => {
                       if (!renamingNode || renameError) return
-                      const nextLabel = nodeEditLabel.trim() || sanitizedNextNodeId
+                      const nextLabel = nodeEditLabel.trim()
                       renameNode(renamingNode, sanitizedNextNodeId, nextLabel)
                       updateNode(sanitizedNextNodeId, { label: nextLabel, color: nodeEditColor })
                       setRenamingNode(null)


### PR DESCRIPTION
Closes #27\n\n- Replace node context menu "Rename" with "Edit node"\n- Edit node dialog now includes Name, Node ID (sanitized + duplicate validation), and Colour picker\n- Keeps existing rename/id-clean behaviour while adding colour editing